### PR TITLE
glass database: use reference_path as fallback path and added exception

### DIFF
--- a/ray_tracing/glass_function/refractiveIndex.py
+++ b/ray_tracing/glass_function/refractiveIndex.py
@@ -21,7 +21,7 @@ import os
 import yaml
 import sys
 import argparse
-import numpy 
+import numpy
 
 
 class RefractiveIndex:
@@ -60,6 +60,10 @@ class RefractiveIndex:
     def getMaterialFilename(self, shelf, book, page):
         cwd = os.getcwd()
         rootdir = cwd + "/opticspy/ray_tracing/glass_database/"
+        if not os.path.exists(rootdir):
+            rootdir = self.referencePath
+            if not os.path.exists(rootdir):
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), rootdir)
         glass_catalog = book
         filename = page + '.yml'
         for root, subFolders, files in os.walk(rootdir):


### PR DESCRIPTION
If I want to use the code just as it is, without installing it, e.g. from a jupyter notebook the glasses cannot be loaded. I fixed this by using the reference path as a fallback and also raise an exception of nothing can be found.